### PR TITLE
Remove stray `</div>` end tag and fix indent

### DIFF
--- a/pelican-chameleon-5e2d5ab49fc551b6becec539b211bfe872ebe836/templates/macro.html
+++ b/pelican-chameleon-5e2d5ab49fc551b6becec539b211bfe872ebe836/templates/macro.html
@@ -146,25 +146,24 @@
 {% macro footer() %}
   <nav id="footer" class="navbar navbar-default">
     <div class="container">
-        <p id="footer-text" class="navbar-text text-center">
-          <span id="engine">
-            Compiled using
-            <a href="https://docs.getpelican.com">Pelican</a>
-          </span>
-          <span id="theme">
-            with theme
-            <a href="https://github.com/yuex/pelican-chameleon">Chameleon</a>
-          </span>
-          <span id="bootstrap">
-            on top of
-            <a href="https://getbootstrap.com/docs/3.4/">Bootstrap 3</a>
-          </span>
-          <span id="bootswatch">
-            and
-            <a href="https://bootswatch.com/3/paper/">Bootswatch &quot;Paper&quot;</a>
-          </span>
-        </p>
-      </div>
+      <p id="footer-text" class="navbar-text text-center">
+        <span id="engine">
+          Compiled using
+          <a href="https://docs.getpelican.com">Pelican</a>
+        </span>
+        <span id="theme">
+          with theme
+          <a href="https://github.com/yuex/pelican-chameleon">Chameleon</a>
+        </span>
+        <span id="bootstrap">
+          on top of
+          <a href="https://getbootstrap.com/docs/3.4/">Bootstrap 3</a>
+        </span>
+        <span id="bootswatch">
+          and
+          <a href="https://bootswatch.com/3/paper/">Bootswatch &quot;Paper&quot;</a>
+        </span>
+      </p>
     </div>
   </nav>
 {% endmacro %}


### PR DESCRIPTION
The template contains an extra closing </div> tag that should not be there.
There probably was a div container that has been removed and the closing tag was forgotten. (The indent implies this.) Also made the indent consistent.