### PR TITLE
Replace old-style content-type header with modern charset header

### DIFF
--- a/pelican-chameleon-5e2d5ab49fc551b6becec539b211bfe872ebe836/templates/base.html
+++ b/pelican-chameleon-5e2d5ab49fc551b6becec539b211bfe872ebe836/templates/base.html
@@ -2,8 +2,8 @@
 {% from 'macro.html' import genurl with context %}
 <html lang="{{ DEFAULT_LANG }}">
 <head>
+    <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
     <meta name="description" content="{{ SITENAME }}">
     <meta name="author" content="{{ AUTHOR }}">
     {% if FAVICON and FAVICON_TYPE %}


### PR DESCRIPTION
Also move charset header before anything else (recommended to have it as early as possible, so parsers know the charset early).