### PR TITLE
Remove discouraged `type` attribute from `style` tag

### DIFF
--- a/pelican-chameleon-5e2d5ab49fc551b6becec539b211bfe872ebe836/templates/base.html
+++ b/pelican-chameleon-5e2d5ab49fc551b6becec539b211bfe872ebe836/templates/base.html
@@ -22,7 +22,7 @@
     {% endif %}
 
     {% if BS3_THEME %}
-    <link rel="stylesheet" href="{{ genurl(BS3_THEME) }}" type="text/css">
+    <link rel="stylesheet" href="{{ genurl(BS3_THEME) }}">
     {% endif %}
 
     <link rel="stylesheet" href="{{ genurl( '/theme/css/main.css' ) }}">


### PR DESCRIPTION
The `type="text/css"` attribute has no effect (it is the default and only valid value) and the WhatWG specification recommends to omit it:
https://html.spec.whatwg.org/#attr-style-type