### PR TITLE
Remove unneeded `role="navigation"` from `nav` tag

### DIFF
--- a/pelican-chameleon-5e2d5ab49fc551b6becec539b211bfe872ebe836/templates/macro.html
+++ b/pelican-chameleon-5e2d5ab49fc551b6becec539b211bfe872ebe836/templates/macro.html
@@ -78,7 +78,7 @@
 {% endmacro %}
 
 {% macro navbar(link) %}
-  <nav id="navbar" class="navbar navbar-default" role="navigation">
+  <nav id="navbar" class="navbar navbar-default">
     <div class="container">
 
       <!--navbar-header-->


### PR DESCRIPTION
`<nav>` automatically has the naviation role and having this attribute generates a warning in the W3C validator, see, e.g.: https://validator.w3.org/nu/?doc=https%3A%2F%2Flibexpat.github.io%2Fdoc%2Fxml-security%2F

(says "Warning: The navigation role is unnecessary for element nav.")

See also:
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/navigation_role