### PR TITLE
Remove unneeded trailing slashes from tags

### DIFF
--- a/content/pages/contribute-website.md
+++ b/content/pages/contribute-website.md
@@ -41,7 +41,7 @@ To add new pages, please:
    the "Latest News" section at the front page (`content/pages/welcome.md`).
 
 
-<br/>
+<br>
 We are looking forward to your contribution!
 
 The Expat development team

--- a/content/pages/custom-encodings.md
+++ b/content/pages/custom-encodings.md
@@ -384,16 +384,16 @@ I wouldn't expect to encounter anything like it in real life.
 
 * We map the bytes 0x00 to 0x7F to the codepoints U+0000 to U+007F
   (i.e. we will leave ASCII alone).
-* 0x80 is the first byte of a three-byte sequence `s`:<br/>
+* 0x80 is the first byte of a three-byte sequence `s`:<br>
   ```
   codepoint = s[1] * 256 + s[2]
   ```
-  <br/>`s[1]` is remembered as the _page_ for 0x81 sequences (below).
-* 0x81 is the first byte of a two-byte sequence `s`:<br/>
+  <br>`s[1]` is remembered as the _page_ for 0x81 sequences (below).
+* 0x81 is the first byte of a two-byte sequence `s`:<br>
   ```
   codepoint = page * 256 + s[1]
   ```
-  <br/>If no page has yet been set (by an 0x80 sequence), it defaults
+  <br>If no page has yet been set (by an 0x80 sequence), it defaults
   to 0.
 * 0x82 is the first byte of a two-byte sequence, the codepoint of
   which is the value of the second byte.  This makes codepoints in the

--- a/content/pages/packages.md
+++ b/content/pages/packages.md
@@ -3,7 +3,7 @@ Date: 2018-08-19
 License: MIT
 slug: packages
 
-> Please note, **this website is work-in-progress**.<br />
+> Please note, **this website is work-in-progress**.<br>
 Be encouraged to [join improving this website](../contribute-website/).
 Thank you!
 

--- a/content/pages/users.md
+++ b/content/pages/users.md
@@ -3,7 +3,7 @@ Date: 2019-09-15
 License: MIT
 slug: users
 
-> Please note, **this website is work-in-progress**.<br />
+> Please note, **this website is work-in-progress**.<br>
 Be encouraged to [join improving this website](../contribute-website/).
 Thank you!
 

--- a/content/pages/walkthrough2.md
+++ b/content/pages/walkthrough2.md
@@ -1274,10 +1274,10 @@ Seriously.  Trust the medical profession on this one.
 
 <a name="lightbrigade">5</a>:
 
-> Theirs not to make reply,<br />
-Theirs not to reason why,<br />
-Theirs but to do and die,<br />
-Into the valley of Death<br />
+> Theirs not to make reply,<br>
+Theirs not to reason why,<br>
+Theirs but to do and die,<br>
+Into the valley of Death<br>
 Rode the six hundred.
 
 From _The Charge of the Light Brigade_ by Alfred, Lord Tennyson,

--- a/content/pages/welcome.md
+++ b/content/pages/welcome.md
@@ -26,7 +26,7 @@ url:
 
 # What is Expat?
 
-Welcome to Expat, a stream-oriented XML parser library written in C.<br/>
+Welcome to Expat, a stream-oriented XML parser library written in C.<br>
 Expat excels with files too large to fit RAM, and
 where performance and flexibility are crucial.
 

--- a/content/pages/xml-security.md
+++ b/content/pages/xml-security.md
@@ -2,7 +2,7 @@ Title: XML Security
 Date: 2025-11-24
 License: MIT
 
-> Please note, **this website is work-in-progress**.<br />
+> Please note, **this website is work-in-progress**.<br>
 Be encouraged to [join improving this website](../../doc/contribute-website/).
 Thank you!
 


### PR DESCRIPTION
Trailing slashes like in `<br/>` are not needed in HTML (only in XHTML, which this page is not using) and are discouraged by the W3C validator. ("Trailing slash on void elements has no effect and interacts badly with unquoted attribute values.")