### PR TITLE
Change `<a name=...>` to `<a id=...>`

### DIFF
--- a/content/pages/common-pitfalls.md
+++ b/content/pages/common-pitfalls.md
@@ -12,7 +12,7 @@ License: MIT
 * [XML 1.1 and XML 1.0 Fifth Edition are not supported](#xml-version)
 
 
-# <a name="split-character-data"></a> Character data may be split across multiple handler calls
+# <a id="split-character-data"></a> Character data may be split across multiple handler calls
 
 If you register a character data handler with
 `XML_SetCharacterDataHandler()`, you might expect that you would be
@@ -33,7 +33,7 @@ and end element handlers.  If you know how your character data will be
 structured, you may well be able to do better than that.
 
 
-# <a name="nested-parser-creation-time"></a> External entity sub-parsers must be created *after* parsing has started
+# <a id="nested-parser-creation-time"></a> External entity sub-parsers must be created *after* parsing has started
 
 There is a note in the description of
 `XML_ExternalEntityParserCreate()` in `expat.h` that is easy to miss:
@@ -55,7 +55,7 @@ handler is called.  The test suite has a lot of examples of creating
 and disposing of parsers in the `ExternalEntityRefHandler` itself.
 
 
-# <a name="temporary-strings"></a> Strings pass to handlers are only temporary
+# <a id="temporary-strings"></a> Strings pass to handlers are only temporary
 
 Most of the handlers that users register are passed strings of one
 form or another.  A start element handler, for instance, is passed the
@@ -66,7 +66,7 @@ really need one of these string parameters for later, make a copy of
 the string itself (and remember to free that when you're done!).
 
 
-# <a name="free-content-model"></a> Element declaration handlers must free their content models
+# <a id="free-content-model"></a> Element declaration handlers must free their content models
 
 The description of the `XML_ElementDeclHandler` type in `expat.h`
 includes the following remark:
@@ -85,7 +85,7 @@ content models around, for example to validate elements later on, they
 are perfectly at liberty to do so.
 
 
-# <a name="xml-version"></a> XML 1.1 and XML 1.0 Fifth Edition are not supported
+# <a id="xml-version"></a> XML 1.1 and XML 1.0 Fifth Edition are not supported
 
 Expat supports [XML 1.0 Fourth Edition](https://www.w3.org/TR/2006/REC-xml-20060816/).
 It does *not* support:

--- a/content/pages/custom-encodings.md
+++ b/content/pages/custom-encodings.md
@@ -572,14 +572,14 @@ probably just as well.
 
 ## Footnotes
 
-<a name="xmlunicode">1:</a> for simplicity, we are assuming that the
+<a id="xmlunicode">1:</a> for simplicity, we are assuming that the
 library has been compiled to use UTF-8 internally.  If it has been
 compiled for UTF-16 (generally on Windows), we would have to use the
 wide string comparison function `wcscmp()` and a wide string literal.
 A properly paranoid program would use macros defined conditionally on
 `XML_UNICODE`, but that is more work that I want to do for an example.
 
-<a name="lazy">2:</a> in other words, I can't be bothered to do it.
+<a id="lazy">2:</a> in other words, I can't be bothered to do it.
 
 
 &mdash; Rhodri James, 30 August 2017

--- a/content/pages/encodings.md
+++ b/content/pages/encodings.md
@@ -758,14 +758,14 @@ tables and the translation functions to UTF-8 and UTF-16.
 
 ## Footnotes
 
-<a name="stdvtable">1</a>: `STANDARD_VTABLE` fills in fields that only
+<a id="stdvtable">1</a>: `STANDARD_VTABLE` fills in fields that only
 exist when the compiler symbol `XML_MIN_SIZE` is defined.  It is not
 clear to me exactly what this is supposed to do, or even whether the
 library compiles with that symbol defined.  I would have guessed that
 is was for minimising the library's memory footprint, but that doesn't
 appear to be right.
 
-<a name="ns">2</a>: Again, I haven't investigated exactly what
+<a id="ns">2</a>: Again, I haven't investigated exactly what
 `XML_NS` does in any detail yet.  I think it allows you to change the
 character used to mark an XML namespace from a colon to something
 else.  I'm not quite sure why this would be a good idea...

--- a/content/pages/hashtables.md
+++ b/content/pages/hashtables.md
@@ -420,16 +420,16 @@ pre-allocated and not have to do the expensive table expansion again.
 
 ## Footnotes
 
-<a name="C">1</a>: the best description I've heard of C is "it's an
+<a id="C">1</a>: the best description I've heard of C is "it's an
 excellent macro-assembler."  C language constructs map to a relatively
 small number of assembler language instructions on most
 microprocessors.  As a result, it's not at all uncommon for embedded C
 programmers to take careful note of the assembly language output of
 their compilers.
 
-<a name="mischance">2</a>: bad luck.
+<a id="mischance">2</a>: bad luck.
 
-<a name="hashcalc">3</a>: the calculation in `SECOND_HASH()` is a bit
+<a id="hashcalc">3</a>: the calculation in `SECOND_HASH()` is a bit
 confusing (I misread it the first time I studied it!), so let's lay it
 out here.  Assume that `power` is 6 (and `mask` is therefore
 `0b111111`), and suppose that our hash is `0b1111111111111111` to make
@@ -447,7 +447,7 @@ So we use the next three (`power-3`) bits of the hash, shifted left
 one bit.  The least significant bit will then be set to one by
 `PROBE_STEP()`, so no information is wasted.
 
-<a name="simples">4</a>: I'm sorry, I appear to have become infested
+<a id="simples">4</a>: I'm sorry, I appear to have become infested
 with [meerkats](https://en.wikipedia.org/wiki/Compare_the_Meerkat).
 
 &mdash;Rhodri James, 29th June 2017

--- a/content/pages/string-pools.md
+++ b/content/pages/string-pools.md
@@ -747,19 +747,19 @@ the right encoding.
 
 ## Footnotes
 
-<a name="hanging">1</a>: a common image of a linked list is as a
+<a id="hanging">1</a>: a common image of a linked list is as a
 chain, with each link in the chain being an element of the list.  If
 you think of the list head pointer as a loop bolted to the wall, the
 rest of the chain hangs down from that loop.  Linked lists (and other
 structures) are therefore sometimes said to "hang off" their head
 pointers.
 
-<a name="wart">2</a>: "Wart" is used as a term for an unfortunate and
+<a id="wart">2</a>: "Wart" is used as a term for an unfortunate and
 ugly feature in a program, language or similar.  A wart is not
 necessarily a bug, it may simply make certain types of development or
 usage patterns unnecessarily hard, as in this case.
 
-<a name="cunning">3</a>: something is described as cunning if it is
+<a id="cunning">3</a>: something is described as cunning if it is
 very clever, often deceitful.  In recent years it has come to have
 sarcastic overtones, thanks to
 [Blackadder](https://www.bbc.co.uk/programmes/b006xxw3); Baldrick's cry

--- a/content/pages/users.md
+++ b/content/pages/users.md
@@ -11,7 +11,7 @@ __NOTE__: For [bindings and 3rd-party wrappers](../bindings/), please check
 the [dedicated page](../bindings/).
 
 
-# <a name="softward"></a> Software
+# <a id="softward"></a> Software
 
 To be included in this list, the related piece of software needs to be
 [Open Source](https://opensource.org/osd-annotated)
@@ -330,7 +330,7 @@ notable, e.g. be packaged in multiple (unrelated) distributions of GNU/Linux.
     * [ZeroC Ice](https://github.com/zeroc-ice/ice/blob/master/cpp/src/IceXML/Parser.cpp)
 
 
-# <a name="hardware"></a> Hardware
+# <a id="hardware"></a> Hardware
 
 * [Bosch Coach mediaRouter](https://oss.bosch-cm.com/download/coach/2019_08%20Coach%20Media%20Router1162/2019-07-07_FOSS-INF_BCMR-1.1.1162docx.pdf)
 * [Bosch Nyon](https://www.bosch-ebike.com/fileadmin/EBC/eBike-Connect/Nyon_OpenSourceSoftware_MY19_used_licenses.pdf)

--- a/content/pages/walkthrough1.md
+++ b/content/pages/walkthrough1.md
@@ -1191,32 +1191,32 @@ me know if you would like an explanation of anything in particular.
 
 ## Footnotes
 
-<a name="bendknee">1</a>: to kneel or submit, figuratively in this
+<a id="bendknee">1</a>: to kneel or submit, figuratively in this
 case.  A relic of our feudal past.
 
-<a name="poobah">2</a>: a humorous title derived from the character
+<a id="poobah">2</a>: a humorous title derived from the character
 Pooh-Bah in Gilbert and Sullivan's opera _The Mikado_, who listed
 among his various titles "Lord High Everything Else".  Sometimes used
 to mock overly self-important people, but Sebastian really does do
 everything else!
 
-<a name="palm">3</a>: "to palm something off on someone" means to pass
+<a id="palm">3</a>: "to palm something off on someone" means to pass
 responsibility for something to someone.  It is usually used in the
 sense of selling a fake or counterfeit object, though not here.
 
-<a name="hats">4</a>: get ready for a surprise.  Comes from the days
+<a id="hats">4</a>: get ready for a surprise.  Comes from the days
 when men commonly wore hats (think of all those fedora-wearing private
 eyes and investigative reporters of the pulp-era stories and films),
 and you would need to hold on to it if you took a wild journey in an
 open-topped car.
 
-<a name="rabbit">5</a>: _Alice in Wonderland_ by Lewis Carroll.  If
+<a id="rabbit">5</a>: _Alice in Wonderland_ by Lewis Carroll.  If
 you needed this footnote, go and add to your education immediately.
 
-<a name="wodge">6</a>: an undefined but significant amount of
+<a id="wodge">6</a>: an undefined but significant amount of
 something.
 
-<a name="utf83">7</a>: UTF-8 encodes codepoints U+0800 to U+FFFF into
+<a id="utf83">7</a>: UTF-8 encodes codepoints U+0800 to U+FFFF into
 three bytes as follows:
 
     :::
@@ -1224,7 +1224,7 @@ three bytes as follows:
 
 So U+FFFF would become the sequence `0xEF 0xBF 0xBF`.
 
-<a name="solidus">8</a>: "solidus" is the proper technical name for a
+<a id="solidus">8</a>: "solidus" is the proper technical name for a
 slash that no one ever uses.  Erm, maybe I should rephrase that...
 
 &mdash;Rhodri James, 23rd June 2017

--- a/content/pages/walkthrough2.md
+++ b/content/pages/walkthrough2.md
@@ -1255,24 +1255,24 @@ specifically like covered in a future article.
 
 ## Footnotes
 
-<a name="trudge">1</a>: to walk heavily or wearily.  Trudging
+<a id="trudge">1</a>: to walk heavily or wearily.  Trudging
 definitely involves effort.
 
-<a name="horror">2</a>: an expression of dismay or disgust, by
+<a id="horror">2</a>: an expression of dismay or disgust, by
 implication somewhat theatrical.
 
-<a name="roll">3</a>: "roll your own" is a phrase first applied to
+<a id="roll">3</a>: "roll your own" is a phrase first applied to
 cigarettes.  Those who don't like the cigarettes the tobacco companies
 produce can buy paper, filters and tobacco and literally roll a
 cigarette for themselves<sup>[4](#smoking)</sup>.  The phrase has
 become applied to many cases of creating an item for yourself rather
 than buying a pre-made version.
 
-<a name="smoking">4</a>: [smoking is bad for your
+<a id="smoking">4</a>: [smoking is bad for your
 health](https://www.nhs.uk/smokefree/why-quit/smoking-health-problems).
 Seriously.  Trust the medical profession on this one.
 
-<a name="lightbrigade">5</a>:
+<a id="lightbrigade">5</a>:
 
 > Theirs not to make reply,<br />
 Theirs not to reason why,<br />

--- a/content/pages/xml-security.md
+++ b/content/pages/xml-security.md
@@ -13,7 +13,7 @@ Thank you!
 * [Billion laughs attack](#billion-laughs)
 
 
-# <a name="external-entities"></a> External entities (XXE)
+# <a id="external-entities"></a> External entities (XXE)
 
 [**X**ML e**X**ternal **E**ntity (XXE) vulnerabilities](https://en.wikipedia.org/wiki/XML_external_entity_attack)
 are a common security problem in applications that parse XML files.
@@ -28,7 +28,7 @@ Configuring such a handler is therefore risky and should not be done if untruste
 expected.
 
 
-# <a name="billion-laughs"></a> Billion laughs attack
+# <a id="billion-laughs"></a> Billion laughs attack
 
 By recursively nesting entities, it is possible to have a relatively small XML input file that generates a
 huge output after processing entities and/or takes a long time to process. In case of high memory


### PR DESCRIPTION
The `name` attribute for the `a` tag is deprecated in HTML5 and `id` should be used instead. This causes an error message in the W3C validator.

See also:
https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a#name